### PR TITLE
Fix score submission crash and improve packet error logging

### DIFF
--- a/app/api/domains/cho.py
+++ b/app/api/domains/cho.py
@@ -274,8 +274,9 @@ async def bancho_handler(
         with memoryview(await request.body()) as body_view:
             for packet in BanchoPacketReader(body_view, packet_map):
                 await packet.handle(player)
-    except:
-        log(f"Error handling packet from {player}.", Ansi.LRED, 
+    except Exception:
+        log(f"Error handling packet from {player}.", Ansi.LRED,
+            exc_info=True,
             extra={
                 "Client-IP": ip,
                 "Request-Headers": request.headers,

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -738,9 +738,7 @@ if app.settings.CHEAT_SERVER:
                 else:
                     score.status = SubmissionStatus.FAILED
 
-            if score_time is not None:
-                if fail_time is not None:
-                    score.time_elapsed = int(score_time) if score.passed else int(fail_time)
+            score.time_elapsed = int(score_time) if score.passed else int(fail_time)
 
             # TODO: re-implement pp caps for non-whitelisted players?
 

--- a/app/logging.py
+++ b/app/logging.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from datetime import datetime
 import logging.config
 from logging.handlers import HTTPHandler
@@ -332,7 +333,8 @@ def log(
     logger: str = '',
     level: int = logging.INFO,
     levelow: bool = False,
-    *args
+    exc_info: bool = False,
+    *args,
 ) -> None:
     """\
     A thin wrapper around the stdlib logging module to handle mostly
@@ -410,7 +412,7 @@ def log(
         lineno=info.lineno,
         msg=f"{msg}",
         args=args or None,
-        exc_info=None,
+        exc_info=sys.exc_info() if exc_info else None,
         func=info.function
     )
     

--- a/app/logging.py
+++ b/app/logging.py
@@ -412,7 +412,7 @@ def log(
         lineno=info.lineno,
         msg=f"{msg}",
         args=args or None,
-        exc_info=sys.exc_info() if exc_info else None,
+        exc_info=exc_info,
         func=info.function
     )
     


### PR DESCRIPTION
## Summary
- Fix `'Score' object has no attribute 'time_elapsed'` error on every score submission — the nested `if score_time is not None: if fail_time is not None:` guard meant `time_elapsed` was only set when both values were present, which almost never happens (passed scores only have `score_time`, failed scores only have `fail_time`)
- Fix bare `except:` in the bancho packet handler to `except Exception:` so it no longer catches `KeyboardInterrupt`/`SystemExit`
- Add `exc_info` param to the `log()` function and use it in the packet handler so full tracebacks are logged when errors occur

## Test plan
- [ ] Submit a passing score and verify no `time_elapsed` AttributeError
- [ ] Submit a failing score and verify no `time_elapsed` AttributeError
- [ ] Verify `time_elapsed` is correctly stored in the database after submission
- [ ] Trigger a packet handler error and verify the full traceback appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)