### PR TITLE
Fix score stats updating wrong gamemode

### DIFF
--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -877,7 +877,7 @@ if app.settings.CHEAT_SERVER:
 
         # get the current stats, and take a
         # shallow copy for the response charts.
-        stats = score.player.gm_stats
+        stats = score.player.stats[score.mode]
         prev_stats = copy.copy(stats)
 
         # stuff update for all submitted scores
@@ -1503,7 +1503,7 @@ else:
 
         # get the current stats, and take a
         # shallow copy for the response charts.
-        stats = score.player.gm_stats
+        stats = score.player.stats[score.mode]
         prev_stats = copy.copy(stats)
 
         # stuff update for all submitted scores


### PR DESCRIPTION
## Summary
- `gm_stats` uses `player.status.mode` (vanilla mode 0-3 from client status), but `score.mode` includes relax/autopilot variants (0-8)
- A relax std submission (mode 4) would incorrectly update vanilla std (mode 0) stats
- Both score submission handlers are fixed

## Test plan
- [ ] Submit a relax score and verify the correct mode's stats are updated
- [ ] Submit a vanilla score and verify stats still update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)